### PR TITLE
#27: Add tests for Keywords.tsx

### DIFF
--- a/server/elsst.ts
+++ b/server/elsst.ts
@@ -14,6 +14,7 @@
 import express from "express";
 import { logger } from "./logger";
 import fetch from 'node-fetch';
+import { TermURIResult } from "../common/metadata";
 
 const SKOSMOS_URL = process.env.SEARCHKIT_SKOSMOS_URL || "https://thesauri.cessda.eu";
 const ELSST_VOCABULARY = process.env.SEARCHKIT_ELSST_VOCABULARY || "elsst-4";
@@ -25,15 +26,12 @@ interface SkosmosLookupResponse {
   }[];
 }
 
-export interface TermURIResult extends Record<string, string> {}
-
 /**
  * Cache for ELSST terms
  */
 const termCache = new Map<string, string | null>();
 
 async function getELSSTTerm(labels: string[], lang: string): Promise<TermURIResult> {
-
 
   const termUris = labels.map(async originalLabel => {
     // Normalise the label by converting it to upper case

--- a/src/components/Keywords.tsx
+++ b/src/components/Keywords.tsx
@@ -74,7 +74,7 @@ export class Keywords extends React.Component<Props, State> {
     for (let i = 0; i < field.length; i++) {
       if (field[i]) {
         const value = callback(field[i]);
-        elements.push(<span className="tag" lang={this.props.lang} key={i}>{value}</span>);
+        elements.push(<span className="tag" data-testid="tag" lang={this.props.lang} key={i}>{value}</span>);
       }
     }
 
@@ -97,7 +97,7 @@ export class Keywords extends React.Component<Props, State> {
   render(): React.ReactNode {
     const { t } = this.props;
     return (<>
-      <div className="tags">
+      <div className="tags" data-testid="tags">
         {this.generateElements(this.state.isExpanded ? this.props.keywords : this.props.keywords.slice(0, this.props.keywordLimit),
           keywords => {
             // If the term is a valid ELSST term, also link to ELSST
@@ -107,7 +107,7 @@ export class Keywords extends React.Component<Props, State> {
               {this.state.elsstURLs[keywords.term] &&
                 <span className="is-inline-flex is-align-items-center">&nbsp;(
                   <a href={this.state.elsstURLs[keywords.term]} rel="noreferrer" target="_blank"
-                    className="is-inline-flex is-align-items-center">
+                    className="is-inline-flex is-align-items-center" data-testid="elsst-link">
                     <span className="icon"><FaExternalLinkAlt/></span>ELSST
                   </a>)
                 </span>
@@ -116,7 +116,7 @@ export class Keywords extends React.Component<Props, State> {
           }
         )}
         {this.props.isExpandDisabled && this.props.keywords.length > this.props.keywordLimit &&
-          <span className="tag">
+          <span className="tag" data-testid="tag">
             <span>&nbsp;({this.props.keywords.length - this.props.keywordLimit}&nbsp;</span>
             <span>{t("more")}</span>
             <span>)</span>

--- a/tests/src/components/Keywords.tsx
+++ b/tests/src/components/Keywords.tsx
@@ -1,0 +1,163 @@
+// Copyright CESSDA ERIC 2017-2024
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import React from 'react';
+import Keywords, { Props } from '../../../src/components/Keywords';
+import { TermURIResult, TermVocabAttributes } from '../../../common/metadata';
+import { getELSSTTerm } from '../../../src/utilities/elsst';
+import i18n from '../../../src/i18n/config';
+import { act, render } from '../../testutils';
+
+const promise = Promise.resolve({});
+
+// Mock out the module that sends requests to the server
+jest.mock('../../../src/utilities/elsst.ts', () => {
+  return {
+    __esModule: true,
+    getELSSTTerm: jest.fn(() => promise)
+  }
+});
+
+const initialProps: Props = {
+  keywords: [],
+  lang: "en",
+  keywordLimit: 12,
+  t: i18n.t,
+  i18n: i18n,
+  tReady: true
+}
+
+// Mock props and shallow render component for test.
+function setup(providedProps: Partial<Props> = {}) {
+  const props: Props = {
+    ...initialProps,
+    ...providedProps
+  };
+  const renderResult = render(<Keywords {...props} />);
+  return {
+    props,
+    renderResult: renderResult
+  };
+}
+
+function getKeyword(term: string): TermVocabAttributes {
+  return {
+    term: term,
+    vocab: "",
+    vocabUri: "",
+    id: ""
+  }
+}
+
+describe('Keywords component', () => {
+  it('should render', () => {
+    const { renderResult: renderResult } = setup();
+    const tagContainer = renderResult.getByTestId("tags");
+    expect(tagContainer).toBeInTheDocument();
+  });
+
+  it('should render keywords', () => {
+    const keywords = ["1", "2", "3", "4"];
+
+    const { renderResult: renderResult, props } = setup({
+      keywords: keywords.map(t => getKeyword(t))
+    });
+
+    // Find all tag elements
+    const tagElements = renderResult.getAllByTestId("tag");
+
+    // There should be 4 keywords
+    expect(tagElements).toHaveLength(4);
+
+    // When rendering the component should have requested ELSST terms for the keywords
+    expect(getELSSTTerm).toHaveBeenCalledWith(keywords, props.lang, expect.anything());
+  });
+
+  it('should link ELSST terms and limit fetching according to given keyword limit when expanding is disabled', async () => {
+    const linkELSST = "https://elsst.cessda.eu/test/";
+
+    // Mock implementation of getELSSTTerm()
+    (getELSSTTerm as jest.MockedFn<typeof getELSSTTerm>).mockImplementation((labels) => {
+      const destObject: TermURIResult = {};
+
+      // Provide an ELSST link for each term, except when l is 3 to test term not having a link
+      labels.forEach(l => {
+        if (l !== "3") {
+          destObject[l] = `${linkELSST}${l}`;
+        }
+      });
+
+      return Promise.resolve(destObject);
+    });
+
+    const keywords = ["1", "2", "3", "4", "5", "6", "7"];
+
+    const { renderResult: renderResult, props } = setup({
+      keywords: keywords.map(t => getKeyword(t)),
+      keywordLimit: 4,
+      isExpandDisabled: true
+    });
+
+    // When rendering the component should have requested ELSST terms for the keywords
+    // It should also only request term for the first 4 keywords because of keyword limit and disabled expanding
+    expect(getELSSTTerm).toHaveBeenCalledWith(["1", "2", "3", "4"], props.lang, expect.anything());
+
+    // The terms with ELSST link provided should link to ELSST
+    const tagsELSSTFound = (await renderResult.findAllByTestId("elsst-link")).map((linkELSSTElement) => {
+      // Find link to ELSST by it opening in a new tab/window
+      expect(linkELSSTElement).toBeInTheDocument();
+      return linkELSSTElement.getAttribute("href")?.includes(linkELSST);
+    });
+    // Limit is 4, expect 3 elements to be found - all with ELSST links
+    expect(tagsELSSTFound).toEqual([true, true, true]);
+  });
+
+  it('should toggle between showing limited number of keywords and showing all keywords', () => {
+    const keywords = ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15"];
+
+    const { renderResult: renderResult } = setup({
+      keywords: keywords.map(t => getKeyword(t))
+    });
+
+    // There should be limited number of keywords when not expanded
+    expect(renderResult.getAllByTestId("tag")).toHaveLength(12);
+
+    // All keywords should be shown when expanded
+    act(() => renderResult.getByTestId("expand-keywords").click());
+    expect(renderResult.getAllByTestId("tag")).toHaveLength(15);
+  });
+
+  it('should abort ELSST term fetch when unmounting', async () => {
+    const keywords = ["1", "2", "3", "4"];
+
+    const abortSpy = jest.spyOn(AbortController.prototype, 'abort');
+
+    const { renderResult: enzymeWrapper } = setup({
+      keywords: keywords.map(t => getKeyword(t))
+    });
+
+    expect(abortSpy).toBeCalledTimes(0);
+
+    // Await the promise - needed because otherwise setState() could be called on the unmounted component
+    // See https://github.com/enzymejs/enzyme/issues/2278 for a description of the issue
+    await promise;
+
+    // Unmount the component
+    enzymeWrapper.unmount();
+
+    expect(abortSpy).toBeCalledTimes(1);
+
+    // Restore the original implementation
+    abortSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
This PR also unifies the `TermURIResult` type definition