### PR TITLE
#692: Add support for Data access category Uncategorized

### DIFF
--- a/common/metadata.ts
+++ b/common/metadata.ts
@@ -30,8 +30,8 @@ export interface CMMStudy {
   dataCollectionYear?: number;
   /** Data collection free text */
   dataCollectionFreeTexts: DataCollectionFreeText[];
-  /** Data access Open/Restricted */
-  dataAccess?: string;
+  /** Data access Open/Restricted/Uncategorized */
+  dataAccess: string;
   /** Terms of data access */
   dataAccessFreeTexts: string[];
   /** Data access url */
@@ -200,7 +200,7 @@ export function getStudyModel(source: Partial<CMMStudy> | undefined, highlight?:
     fileLanguages: source.fileLanguages || [],
     publisher: source.publisher as Publisher,
     publicationYear: source.publicationYear || '',
-    dataAccess: source.dataAccess,
+    dataAccess: source.dataAccess || '',
     dataAccessFreeTexts: (source.dataAccessFreeTexts || []).map(text => stripHTMLElements(text)),
     dataAccessUrl: source.dataAccessUrl,
     studyNumber: source.studyNumber || '',

--- a/src/components/Detail.tsx
+++ b/src/components/Detail.tsx
@@ -65,7 +65,7 @@ const Detail = (props: Props) => {
   const item = props.item;
   const headings = props.headings;
   const truncatedAbstractLength = 2000;
-  
+
 
   const [abstractExpanded, setAbstractExpanded] = useState(props.item.abstract.length < truncatedAbstractLength);
   const exportMetadataOptions: Option[] = [
@@ -294,7 +294,7 @@ const Detail = (props: Props) => {
     }
   }
 
- 
+
   /**
    * Formats the given creator inside span element with as much information as possible, preferably
    * creator name, creator affiliation and research identifier. Research identifier will also include
@@ -409,7 +409,7 @@ const Detail = (props: Props) => {
                         &nbsp;&nbsp;</span>
                     </a>
                   )}
-               
+
                   <a
                     href={`/api/json/${currentIndex.indexName}/${encodeURIComponent(item.id)}`}
                     rel="noreferrer"
@@ -503,7 +503,7 @@ const Detail = (props: Props) => {
               {!currentThematicView.excludeFields.includes('dataAccess') &&
                 <>
                   {generateHeading('dataAccess')}
-                  <p>{item.dataAccess || t("language.notAvailable.information")}</p>
+                  <p>{item.dataAccess === 'Uncategorized' ? `${item.dataAccess}, see Terms of data access` : item.dataAccess || t("language.notAvailable.information")}</p>
                 </>
               }
 

--- a/src/components/Result.tsx
+++ b/src/components/Result.tsx
@@ -213,23 +213,24 @@ const Result: React.FC<ResultProps> = ({ hit }) => {
                 </div>
               </div>
             )}
-            {hit.dataAccess &&
+            {hit.dataAccess && (hit.dataAccess === "Open" || hit.dataAccess === "Restricted") &&
               <div className="control">
+                <span className="button is-small is-white bg-w pe-none mln-5 mrn-5">
+                  {t("metadata.dataAccess")}:
+                </span>
                 <span className="button is-small is-white bg-w pe-none mrn-5">
                   {hit.dataAccess === "Open" ? (
                     <span className="icon is-small">
                       <FaLockOpen/>
                     </span>
-                  ) : (
+                  ) : hit.dataAccess === "Restricted" && (
                     <span className="icon is-small">
                       <FaLock/>
                     </span>
                   )}
-                  <span>{t("metadata.dataAccess")}:</span>
+                  <span>{hit.dataAccess}</span>
                 </span>
-                <span className="button is-small is-white bg-w pe-none mln-5 mrn-5">
-                  {hit.dataAccess}
-                </span>
+
               </div>
             }
             <div className="control">

--- a/src/i18n/en/translation.json
+++ b/src/i18n/en/translation.json
@@ -54,7 +54,7 @@
     "dataAccess": {
       "label": "Data access",
       "tooltip": {
-        "content": "Data access mapped from <a href=\"https://wiki.surfnet.nl/display/standards/info-eu-repo#infoeurepo-AccessRights\">Access Rights CV</a> or custom mapping from data access terms of metadata provider. Data access has not been mapped for all metadata providers (no CV values or custom mappings available yet).",
+        "content": "Data access is mapped using the <a href=\"https://wiki.surfnet.nl/display/standards/info-eu-repo#infoeurepo-AccessRights\">Access Rights CV</a> or custom Service Provider specific mappings. 'Uncategorized' means access terms haven't been mapped yet, but full details are usually available on the study page or the Service Provider's catalogue.",
         "ariaLabel": "Tooltip button for Data access filter"
       }
     },

--- a/tests/common/metadata.ts
+++ b/tests/common/metadata.ts
@@ -42,6 +42,7 @@ describe('Metadata utilities', () => {
             { name: 'Joe Bloggs, University of Essex' }
           ],
           code: 'UKDS',
+          dataAccess: 'Restricted',
           dataAccessFreeTexts: ['Data Access Free Texts'],
           dataCollectionFreeTexts: [],
           dataCollectionPeriodEnddate: '',
@@ -152,6 +153,7 @@ describe('Metadata utilities', () => {
           { name: 'John Smith', affiliation: 'University of Essex', identifier: { id: "0", type: "Test", uri: "http://localhost/0" } },
           { name: 'Joe Bloggs, University of Essex' }
         ],
+        dataAccess: 'Restricted',
         dataAccessFreeTexts: ['Data Access Free Texts'],
         dataCollectionFreeTexts: [],
         dataCollectionPeriodEnddate: '',
@@ -258,6 +260,7 @@ describe('Metadata utilities', () => {
         classifications: [],
         code: undefined,
         creators: [],
+        dataAccess: '',
         dataAccessFreeTexts: [],
         dataCollectionFreeTexts: [],
         dataCollectionPeriodEnddate: '',
@@ -325,6 +328,7 @@ describe('Metadata utilities', () => {
             { name: 'Joe Bloggs, University of Essex' }
           ],
           code: 'UKDS',
+          dataAccess: 'Restricted',
           dataAccessFreeTexts: ['Data Access Free Texts', 'https://creativecommons.org/licenses/by/4.0'],
           dataCollectionFreeTexts: [],
           dataCollectionPeriodEnddate: '',
@@ -468,6 +472,7 @@ describe('Metadata utilities', () => {
             { name: 'Joe Bloggs, University of Essex' }
           ],
           code: 'UKDS',
+          dataAccess: 'Uncategorized',
           dataAccessFreeTexts: [],
           dataCollectionFreeTexts: [],
           dataCollectionPeriodEnddate: '',

--- a/tests/common/mockdata.ts
+++ b/tests/common/mockdata.ts
@@ -27,6 +27,7 @@ export const mockStudy: CMMStudy = {
     { name: 'Maija Meikäläinen', affiliation: 'Tampere University', identifier: { id: "1" } }
   ],
   code: 'UKDS',
+  dataAccess: 'Restricted',
   dataAccessFreeTexts: [
     "Data access terms and conditions"
   ],

--- a/tests/src/components/Result.tsx
+++ b/tests/src/components/Result.tsx
@@ -220,8 +220,15 @@ it('should display "Restricted" when data access is Restricted', () => {
   expect(screen.getByText('Restricted')).toBeInTheDocument();
 });
 
-it('should not display data access when it is undefined', () => {
-  render(<Result hit={{ ...baseMockHit, dataAccess: undefined }} />);
+it('should not display data access when it is Uncategorized', () => {
+  render(<Result hit={{ ...baseMockHit, dataAccess: 'Uncategorized' }} />);
+
+  expect(screen.queryByText('Open')).not.toBeInTheDocument();
+  expect(screen.queryByText('Restricted')).not.toBeInTheDocument();
+});
+
+it('should not display data access when it is empty string', () => {
+  render(<Result hit={{ ...baseMockHit, dataAccess: '' }} />);
 
   expect(screen.queryByText('Open')).not.toBeInTheDocument();
   expect(screen.queryByText('Restricted')).not.toBeInTheDocument();


### PR DESCRIPTION
Displaying the new Data access category 'Uncategorized' as agreed in https://github.com/cessda/cessda.cdc.versions/issues/692.